### PR TITLE
Fix test pipeline loop caused by duplicate triage and workflow races

### DIFF
--- a/.github/workflows/somas-dev-autonomous.yml
+++ b/.github/workflows/somas-dev-autonomous.yml
@@ -13,7 +13,9 @@ permissions:
 jobs:
   autonomous-execution:
     name: Autonomous Pipeline Execution
-    if: github.event.label.name == 'somas:dev' || github.event.label.name == 'somas-project'
+    # Only run on somas:dev label - let somas-pipeline.yml handle somas-project only cases
+    # This prevents duplicate pipeline executions when somas-project is added
+    if: github.event.label.name == 'somas:dev'
     runs-on: ubuntu-latest
     timeout-minutes: 300
 

--- a/.github/workflows/somas-orchestrator.yml
+++ b/.github/workflows/somas-orchestrator.yml
@@ -95,7 +95,38 @@ jobs:
 
             return { issue, requestType };
 
+      - name: Check for Recent Triage Comment
+        id: check_duplicate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Prevent duplicate triage comments from opened+labeled race condition
+            // Check if a triage comment was already posted in the last 60 seconds
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 10
+            });
+
+            const now = new Date();
+            const recentTriageComment = comments.data.find(c => {
+              const commentAge = now - new Date(c.created_at);
+              const isRecent = commentAge < 60000; // 60 seconds
+              const isTriageComment = c.body.includes('SOMAS Triage Agent Initiated') ||
+                                      c.body.includes('@copilot somas-triage');
+              return isRecent && isTriageComment;
+            });
+
+            if (recentTriageComment) {
+              core.info(`Duplicate triage detected - comment #${recentTriageComment.id} exists from ${recentTriageComment.created_at}`);
+              core.setOutput('is_duplicate', 'true');
+            } else {
+              core.setOutput('is_duplicate', 'false');
+            }
+
       - name: Add Triaged Label
+        if: steps.check_duplicate.outputs.is_duplicate != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -107,6 +138,7 @@ jobs:
             });
 
       - name: Invoke Triage Agent
+        if: steps.check_duplicate.outputs.is_duplicate != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -163,6 +195,28 @@ jobs:
               **Confidence Threshold:** If confidence < 0.8, escalate to human (@scotlaclair).
               `
             });
+
+      - name: Add Project Label to Enable Pipeline
+        if: steps.check_duplicate.outputs.is_duplicate != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Add somas-project label to trigger the main pipeline
+            // This enables progression from triage to the full 11-stage pipeline
+            const requestType = '${{ steps.extract.outputs.request_type }}';
+
+            // Only add somas-project for actionable request types
+            if (['change', 'enhancement', 'bug'].includes(requestType)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['somas-project']
+              });
+              core.info(`Added somas-project label for ${requestType} request to enable pipeline`);
+            } else {
+              core.info(`Skipping somas-project label for ${requestType} request type`);
+            }
 
   # Parse agent responses and advance pipeline
   orchestrate:


### PR DESCRIPTION
- Add duplicate triage comment detection in orchestrator workflow
  Prevents duplicate comments when opened+labeled events fire simultaneously
  by checking for recent (60s) triage comments before posting

- Add somas-project label after triage to enable pipeline progression
  Triaged issues now automatically get routed to the main pipeline
  for actionable request types (change, enhancement, bug)

- Fix somas-dev-autonomous.yml to only trigger on somas:dev label
  Prevents duplicate pipeline execution when somas-project is added
  since somas-pipeline.yml already handles somas-project-only cases

Fixes #62

https://claude.ai/code/session_01QaXTQcNxzWXvpTbrh9vjUd